### PR TITLE
Utilise updated sass-lint and fix issues

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,7 +1,5 @@
 options:
   formatter: stylish
-files:
-  include: '/app/echo-base/**/*.s+(a|c)ss'
 rules:
   # Extends
   extends-before-mixins: 1
@@ -17,20 +15,39 @@ rules:
   single-line-per-selector: 1
 
   # Disallows
+  no-color-keywords: 0
+  no-color-literals: 0
+  no-css-comments: 1
   no-debug: 1
   no-duplicate-properties: 1
   no-empty-rulesets: 1
   no-extends: 0
   no-ids: 1
   no-important: 1
-  no-warn: 0
-  no-color-keywords: 0
   no-invalid-hex: 1
-  no-css-comments: 1
-  no-color-literals: 0
+  no-mergeable-selectors: 0
+  no-misspelled-properties: 1
+  no-qualifying-elements: 0
+  no-trailing-zero: 1
+  no-transition-all: 1
+  no-url-protocols: 1
+  no-vendor-prefixes: 1
+  no-warn: 0
+
+  # Nesting
+  force-attribute-nesting: 0
+  force-element-nesting: 1
+  force-pseudo-nesting: 0
+
+  # Name Formats
+  function-name-format: 1
+  mixin-name-format: 1
+  placeholder-name-format: 1
+  variable-name-format: 1
 
   # Style Guide
   border-zero: 1
+  brace-style: 1
   clean-import-paths: 1
   empty-args: 1
   hex-length: 1
@@ -44,11 +61,10 @@ rules:
       -
           include: true
   nesting-depth: 1
-  property-sort-order:
-      - 0
-      -
-          order: 'recess'
+  property-sort-order: 0
   quotes: 1
+  shorthand-values: 1
+  url-quotes: 1
   variable-for-property: 1
   zero-unit: 1
 

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,5 +1,6 @@
 options:
   formatter: stylish
+  merge-default-rules: false
 rules:
   # Extends
   extends-before-mixins: 1

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,6 +1,9 @@
 options:
   formatter: stylish
   merge-default-rules: false
+files:
+  include: 'app/**/*.scss'
+  ignore: 'app/tests/**/*.scss'
 rules:
   # Extends
   extends-before-mixins: 1
@@ -26,7 +29,7 @@ rules:
   no-ids: 1
   no-important: 1
   no-invalid-hex: 1
-  no-mergeable-selectors: 0
+  no-mergeable-selectors: 0 # TODO: Enable once sasstools/sass-lint#339 issue fixed
   no-misspelled-properties: 1
   no-qualifying-elements: 0
   no-trailing-zero: 1

--- a/app/scss/echo-base/defaults/elements/_input.scss
+++ b/app/scss/echo-base/defaults/elements/_input.scss
@@ -122,8 +122,7 @@ $input-search-box-sizing: $global-box-sizing !default;
     font-size: $input-text-font-size;
     font-weight: $input-text-font-weight;
     line-height: $input-text-line-height;
-    -moz-appearance: $input-text-appearance;
-    -webkit-appearance: $input-text-appearance;
+    appearance: $input-text-appearance;
 
     &:focus {
         color: $input-text-color-focus;

--- a/app/scss/echo-base/defaults/elements/_select.scss
+++ b/app/scss/echo-base/defaults/elements/_select.scss
@@ -41,7 +41,7 @@ $select-padding-right: 0.5rem !default;
 $select-margin-bottom: 1rem !default;
 $select-margin-top: 0 !default;
 $select-background-color: palette(echo-base, white) !default;
-$select-background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMTJweCIgeT0iMHB4IiB3aWR0aD0iMjRweCIgaGVpZ2h0PSIzcHgiIHZpZXdCb3g9IjAgMCA2IDMiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDYgMyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PHBvbHlnb24gcG9pbnRzPSI1Ljk5MiwwIDIuOTkyLDMgLTAuMDA4LDAgIi8+PC9zdmc+) !default;
+$select-background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMTJweCIgeT0iMHB4IiB3aWR0aD0iMjRweCIgaGVpZ2h0PSIzcHgiIHZpZXdCb3g9IjAgMCA2IDMiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDYgMyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PHBvbHlnb24gcG9pbnRzPSI1Ljk5MiwwIDIuOTkyLDMgLTAuMDA4LDAgIi8+PC9zdmc+') !default;
 $select-background-repeat: no-repeat !default;
 $select-background-position: 100% center !default;
 $select-border-color: palette(echo-base, grey) !default;
@@ -113,8 +113,7 @@ $select-cursor-disabled: not-allowed !default;
     line-height: $select-line-height;
     text-transform: $select-text-transform;
     letter-spacing: $select-letter-spacing;
-    -moz-appearance: $select-appearance;
-    -webkit-appearance: $select-appearance;
+    appearance: $select-appearance;
 
     // Hide the dropdown arrow shown in newer IE versions
     &::-ms-expand {

--- a/app/scss/echo-base/defaults/elements/_select.scss
+++ b/app/scss/echo-base/defaults/elements/_select.scss
@@ -116,6 +116,7 @@ $select-cursor-disabled: not-allowed !default;
     appearance: $select-appearance;
 
     // Hide the dropdown arrow shown in newer IE versions
+    // TODO: Fix when sass-lint supports comment initiated rule disabling
     &::-ms-expand {
         display: none;
     }

--- a/app/scss/echo-base/defaults/elements/_textarea.scss
+++ b/app/scss/echo-base/defaults/elements/_textarea.scss
@@ -109,8 +109,7 @@ $textarea-cursor-disabled: not-allowed !default;
     line-height: $textarea-line-height;
     text-transform: $textarea-text-transform;
     letter-spacing: $textarea-letter-spacing;
-    -moz-appearance: $textarea-appearance;
-    -webkit-appearance: $textarea-appearance;
+    appearance: $textarea-appearance;
 
     &:focus {
         color: $textarea-color-focus;


### PR DESCRIPTION
This PR updates the config file for sass-lint, adding multiple new rules and also fixes all but one lint warnings.

The last issue can be fixed once sass-lint supports comment rule disabling.